### PR TITLE
Feature custom server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,10 @@ app_service_user: minecrafter
 # Allowed values: Any valid folder
 minecraft_install_folder: /app/minecraft
 
+# The version of minecraft java to install
+# Allowed values: Valid verions of minecraft, use "latest" to get the newest version
+minecraft_java_version: latest
+
 # The name used to identify the service by Systemd
 # Allowed values: Any string
 minecraft_service_name: minecraft

--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -7,9 +7,39 @@
     update_cache: true
   become: true
 
+- name: Get list of available Minecraft builds
+  uri:
+    url: "https://launchermeta.mojang.com/mc/game/version_manifest.json"
+  register: minecraft_vers_list
+
+- name: Search builds for latest version and get build info url
+  set_fact: 
+    minecraft_version_url: "{{ minecraft_vers_list.json | json_query(query)  }}"
+  vars:
+    # Query to look up the latest release of minecraft
+    query: "versions[?id=='{{ minecraft_vers_list.json.latest.release }}'].url"
+  when: minecraft_java_version == "latest"
+
+- name: Search builds for specified version and get build info url
+  set_fact: 
+    minecraft_version_url: "{{ minecraft_vers_list.json | json_query(query)  }}"
+  vars:
+    # Query to look up the minecraft version we specified from the list
+    query: "versions[?id=='{{ minecraft_java_version }}'].url"
+  when: minecraft_java_version != "latest"
+
+- name: Get Minecraft download url from build info
+  uri:
+    url: "{{ minecraft_version_url[0] }}"
+  register: minecraft_version_info
+
+- name: Set Minecraft server download url
+  set_fact: 
+    minecraft_download_url: "{{ minecraft_version_info.json.downloads.server.url }}"
+
 - name: Getting the server app
   get_url:
-    url: https://launcher.mojang.com/v1/objects/3dc3d84a581f14691199cf6831b71ed1296a9fdf/server.jar
+    url: "{{ minecraft_download_url }}"
     dest: "{{ minecraft_install_folder }}"
     owner: "{{ app_service_user }}"
     group: "{{ app_service_user }}"


### PR DESCRIPTION
Noticed that the java server URL wasn't working so I added some tasks to use the Mojang builds API to get the latest (or custom version) of the server.jar file.  Also set the default to "latest" but you can override that var with any version (1.14.3 etc).